### PR TITLE
Managable death markers

### DIFF
--- a/assembly_valheim.WeylandMod.mm/Patch/Player.cs
+++ b/assembly_valheim.WeylandMod.mm/Patch/Player.cs
@@ -1,0 +1,23 @@
+using MonoMod;
+
+#pragma warning disable CS0626
+#pragma warning disable CS0649
+
+namespace WeylandMod
+{
+    [MonoModPatch("global::Player")]
+    internal class PatchPlayer : Player
+    {
+        protected extern void orig_OnDeath();
+
+        protected override void OnDeath()
+        {
+            orig_OnDeath();
+
+            if (ModConfig.Instance.Player.ManageableDeathMarkers.Value)
+            {
+                Minimap.instance.AddPin(transform.position, Minimap.PinType.Death, "", true, false);
+            }
+        }
+    }
+}

--- a/assembly_valheim.WeylandMod.mm/Patch/PlayerProfile.cs
+++ b/assembly_valheim.WeylandMod.mm/Patch/PlayerProfile.cs
@@ -1,0 +1,23 @@
+using MonoMod;
+
+#pragma warning disable CS0626
+#pragma warning disable CS0649
+
+namespace WeylandMod
+{
+    [MonoModPatch("global::PlayerProfile")]
+    internal class PatchPlayerProfile : PlayerProfile
+    {
+        public extern bool orig_HaveDeathPoint();
+
+        public new bool HaveDeathPoint()
+        {
+            if (ModConfig.Instance.Player.ManageableDeathMarkers.Value)
+            {
+                return false;
+            }
+
+            return orig_HaveDeathPoint();
+        }
+    }
+}

--- a/assembly_valheim.WeylandMod.mm/Utils/ModConfig.cs
+++ b/assembly_valheim.WeylandMod.mm/Utils/ModConfig.cs
@@ -14,6 +14,8 @@ namespace WeylandMod
 
         public readonly ServerConfig Server;
 
+        public readonly PlayerConfig Player;
+
         public readonly ExtendedStorageConfig ExtendedStorage;
 
         public static void Create()
@@ -35,6 +37,16 @@ namespace WeylandMod
                 ),
             };
 
+            Player = new PlayerConfig
+            {
+                ManageableDeathMarkers = ConfigFile.Bind(
+                    nameof(Player),
+                    "ManageableDeathMarkers",
+                    true,
+                    "Keep track of all your deaths and delete markers using right click."
+                ),
+            };
+
             ExtendedStorage = new ExtendedStorageConfig
             {
                 Enabled = ConfigFile.Bind(
@@ -49,6 +61,11 @@ namespace WeylandMod
         public class ServerConfig
         {
             public ConfigEntry<bool> SkipPasswordValidation;
+        }
+
+        public class PlayerConfig
+        {
+            public ConfigEntry<bool> ManageableDeathMarkers;
         }
 
         public class ExtendedStorageConfig


### PR DESCRIPTION
All deaths positions are now savable and can be deleted by right clicking on corresponding marker.

fyi @mdsina 